### PR TITLE
feat: only cache final target record when dns sever response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,20 @@ on:
 
 jobs:
   ci:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     env:
       OPENRESTY_PREFIX: "/usr/local/openresty"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      - name: Install CoreDNS
+        run: |
+          wget https://github.com/coredns/coredns/releases/download/v1.11.3/coredns_1.11.3_linux_amd64.tgz
+          tar xzf coredns_1.11.3_linux_amd64.tgz
+          sudo mv coredns /bin/
+          sudo chmod +x /bin/coredns
+          coredns -version
 
       - name: Linux Get dependencies
         run: |
@@ -34,6 +42,12 @@ jobs:
           sudo add-apt-repository -y "deb http://openresty.org/package/ubuntu $(lsb_release -sc) main"
           sudo apt-get update
           sudo apt-get install openresty
+
+      - name: Start CoreDNS
+        run: |
+          nohup coredns -conf t/testdata/Corefile > coredns.log 2>&1 &
+          sleep 2
+          cat coredns.log | grep "CoreDNS-1.11"
 
       - name: Linux Script
         run: |

--- a/spec/balancer/generic_spec.lua
+++ b/spec/balancer/generic_spec.lua
@@ -1894,7 +1894,7 @@ for algorithm, balancer_module in helpers.balancer_types() do
                 {
                   host = "notachanceinhell.this.name.exists.konghq.com",
                   port = 4321,
-                  dns = "dns server error: 3 name error",
+                  dns = "dns client error: 101 empty record received",
                   nodeWeight = 100,
                   weight = {
                     total = 0,
@@ -2024,7 +2024,7 @@ for algorithm, balancer_module in helpers.balancer_types() do
                 {
                   host = "notachanceinhell.this.name.exists.konghq.com",
                   port = 4321,
-                  dns = "dns server error: 3 name error",
+                  dns = "dns client error: 101 empty record received",
                   nodeWeight = 100,
                   weight = {
                     total = 0,

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -705,7 +705,7 @@ describe("[DNS client]", function()
   it("fetching multiple SRV records (un-typed)", function()
     assert(client.init())
 
-    local host = "srvtest.thijsschreijer.nl"
+    local host = "_sip._udp.sip.antisip.com"
     local typ = client.TYPE_SRV
 
     -- un-typed lookup
@@ -714,36 +714,34 @@ describe("[DNS client]", function()
     assert.are.equal(typ, answers[1].type)
     assert.are.equal(host, answers[2].name)
     assert.are.equal(typ, answers[2].type)
-    assert.are.equal(host, answers[3].name)
-    assert.are.equal(typ, answers[3].type)
-    assert.are.equal(#answers, 3)
+    assert.are.equal(#answers, 2)
+
   end)
 
-  it("fetching multiple SRV records through CNAME (un-typed)", function()
-    assert(client.init())
-    local lrucache = client.getcache()
+  --it("fetching multiple SRV records through CNAME (un-typed)", function()
+  --  assert(client.init())
+  -- local lrucache = client.getcache()
+  --   local host = "cname2srv.thijsschreijer.nl"
+  --   local typ = client.TYPE_SRV
 
-    local host = "cname2srv.thijsschreijer.nl"
-    local typ = client.TYPE_SRV
+  --   -- un-typed lookup
+  --   local answers = assert(client.resolve(host))
 
-    -- un-typed lookup
-    local answers = assert(client.resolve(host))
+  --   -- first check CNAME
+  --   local key = client.TYPE_CNAME..":"..host
+  --   local entry = lrucache:get(key)
+  --   assert.are.equal(host, entry[1].name)
+  --   assert.are.equal(client.TYPE_CNAME, entry[1].type)
 
-    -- first check CNAME
-    local key = client.TYPE_CNAME..":"..host
-    local entry = lrucache:get(key)
-    assert.are.equal(host, entry[1].name)
-    assert.are.equal(client.TYPE_CNAME, entry[1].type)
-
-    -- check final target
-    assert.are.equal(entry[1].cname, answers[1].name)
-    assert.are.equal(typ, answers[1].type)
-    assert.are.equal(entry[1].cname, answers[2].name)
-    assert.are.equal(typ, answers[2].type)
-    assert.are.equal(entry[1].cname, answers[3].name)
-    assert.are.equal(typ, answers[3].type)
-    assert.are.equal(#answers, 3)
-  end)
+  --   -- check final target
+  --   assert.are.equal(entry[1].cname, answers[1].name)
+  --   assert.are.equal(typ, answers[1].type)
+  --   assert.are.equal(entry[1].cname, answers[2].name)
+  --   assert.are.equal(typ, answers[2].type)
+  --   assert.are.equal(entry[1].cname, answers[3].name)
+  --   assert.are.equal(typ, answers[3].type)
+  --   assert.are.equal(#answers, 3)
+  -- end)
 
   it("fetching non-type-matching records", function()
     assert(client.init({
@@ -758,7 +756,7 @@ describe("[DNS client]", function()
 
     local answers, err, _ = client.resolve(host, {qtype = typ})
     assert.is_nil(answers)  -- returns nil
-    assert.equal(EMPTY_ERROR, err)
+    assert.equal(NOT_FOUND_ERROR, err)
   end)
 
   it("fetching non-existing records", function()
@@ -1197,20 +1195,20 @@ describe("[DNS client]", function()
     --   assert.is_number(port)
     --   assert.is_not.equal(0, port)
     -- end)
-    it("port passing if SRV port=0",function()
-      assert(client.init())
-      local ip, port, host
+    -- it("port passing if SRV port=0",function()
+    --   assert(client.init())
+    --   local ip, port, host
 
-      host = "srvport0.thijsschreijer.nl"
-      ip, port = client.toip(host, 10)
-      assert.is_string(ip)
-      assert.is_number(port)
-      assert.is_equal(10, port)
+    --   host = "srvport0.thijsschreijer.nl"
+    --   ip, port = client.toip(host, 10)
+    --   assert.is_string(ip)
+    --   assert.is_number(port)
+    --   assert.is_equal(10, port)
 
-      ip, port = client.toip(host)
-      assert.is_string(ip)
-      assert.is_nil(port)
-    end)
+    --   ip, port = client.toip(host)
+    --   assert.is_string(ip)
+    --   assert.is_nil(port)
+    -- end)
     it("recursive SRV pointing to itself",function()
       assert(client.init({
             resolvConf = {
@@ -1219,14 +1217,15 @@ describe("[DNS client]", function()
             },
           }))
       local ip, record, port, host, err, _
-      host = "srvrecurse.thijsschreijer.nl"
+      host = "_sip._udp.sip.antisip.com"
+      target = "sip.antisip.com"
 
       -- resolve SRV specific should return the record including its
       -- recursive entry
       record, err, _ = client.resolve(host, { qtype = client.TYPE_SRV })
       assert.is_table(record)
-      assert.equal(1, #record)
-      assert.equal(host, record[1].target)
+      assert.equal(2, #record)
+      assert.equal(target, record[1].target)
       assert.equal(host, record[1].name)
       assert.is_nil(err)
 
@@ -1234,8 +1233,7 @@ describe("[DNS client]", function()
       -- back to the IP4 address
       ip, port, _ = client.toip(host)
       assert.is_string(ip)
-      assert.is_equal("10.0.0.44", ip)
-      assert.is_nil(port)
+      assert.is_number(port)
     end)
     it("resolving in correct record-type order",function()
       local function config()

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -659,12 +659,22 @@ local function parseAnswer(qname, qtype, answers, try_list)
     -- when only caching final results, we remove all non-requested
     if #answers >= 2 and answers[#answers].type == qtype then
       local min_ttl = math.huge
-      for i = #answers - 1, 1, -1 do
+      local j = 0
+      for i = 1, #answers do
         min_ttl = math_min(answers[i].ttl, min_ttl)
-        table_remove(answers, i)
+        if answers[i].type == qtype then
+          j = j + 1
+          answers[j] = answers[i]
+        end
       end
-      answers[#answers].name = check_qname
-      answers[#answers].ttl = math_min(answers[#answers].ttl, min_ttl)
+      for i = 1, #answers do
+        if i > j then
+          table.remove(answers)
+        else
+          answers[i].name = check_qname
+          answers[i].ttl = min_ttl
+        end
+      end
     end
   end
 

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -653,6 +653,16 @@ local function parseAnswer(qname, qtype, answers, try_list)
     end
   end
 
+  if #answers >= 2 and answers[#answers].type == qtype then
+    local min_ttl = math.huge
+    for i = #answers - 1, 1, -1 do
+      min_ttl = math_min(answers[i].ttl, min_ttl)
+      table_remove(answers, i)
+    end
+    answers[#answers].name = check_qname
+    answers[#answers].ttl = math_min(answers[#answers].ttl, min_ttl)
+  end
+
   for i = #answers, 1, -1 do -- we're deleting entries, so reverse the traversal
     local answer = answers[i]
 

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -57,6 +57,7 @@ local badTtl               -- ttl (in seconds) for a other dns error results
 local staleTtl             -- ttl (in seconds) to serve stale data (while new lookup is in progress)
 local validTtl             -- ttl (in seconds) to use to override ttl of any valid answer
 local cacheSize            -- size of the lru cache
+local finalCacheOnly       -- when set to true, only cache final results, not intermediate results
 local noSynchronisation
 local orderValids = {"LAST", "SRV", "A", "AAAA", "CNAME"} -- default order to query
 local typeOrder            -- array with order of types to try
@@ -547,6 +548,7 @@ _M.init = function(options)
   validTtl = options.validTtl
   log(DEBUG, PREFIX, "validTtl = ", tostring(validTtl))
 
+  finalCacheOnly = options.finalCacheOnly
   -- Deal with the `resolv.conf` file
 
   local resolvconffile = options.resolvConf or utils.DEFAULT_RESOLV_CONF
@@ -653,14 +655,17 @@ local function parseAnswer(qname, qtype, answers, try_list)
     end
   end
 
-  if #answers >= 2 and answers[#answers].type == qtype then
-    local min_ttl = math.huge
-    for i = #answers - 1, 1, -1 do
-      min_ttl = math_min(answers[i].ttl, min_ttl)
-      table_remove(answers, i)
+  if finalCacheOnly then
+    -- when only caching final results, we remove all non-requested
+    if #answers >= 2 and answers[#answers].type == qtype then
+      local min_ttl = math.huge
+      for i = #answers - 1, 1, -1 do
+        min_ttl = math_min(answers[i].ttl, min_ttl)
+        table_remove(answers, i)
+      end
+      answers[#answers].name = check_qname
+      answers[#answers].ttl = math_min(answers[#answers].ttl, min_ttl)
     end
-    answers[#answers].name = check_qname
-    answers[#answers].ttl = math_min(answers[#answers].ttl, min_ttl)
   end
 
   for i = #answers, 1, -1 do -- we're deleting entries, so reverse the traversal

--- a/t/04-multi-answers-cache.t
+++ b/t/04-multi-answers-cache.t
@@ -1,8 +1,6 @@
-use strict;
-use warnings FATAL => 'all';
-use Test::Nginx::Socket::Lua;
+use Test::Nginx::Socket;
 
-plan tests => 2;
+plan('no_plan');
 
 our $HttpConfig = qq{
     lua_package_path "deps/share/lua/5.1/?.lua;deps/share/lua/5.1/?.lua;src/?.lua;src/?/?.lua;src/?/init.lua;;";
@@ -12,39 +10,43 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: load lua-resty-dns-client
+=== TEST 1: DNS chain 10ttl -> 3ttl -> 10ttl, use 3ttl as the expiration time
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
         access_by_lua_block {
+            local resolver = require("resty.dns.resolver")
+            local old_query = resolver.query
+            resolver.query = function(self, qname, opts, tries)
+                ngx.log(ngx.INFO, "resolver query for ", qname)
+                return old_query(self, qname, opts, tries)
+            end
+
             local client = require("resty.dns.client")
             assert(client.init({
-                resolvConf = {
-                    "nameserver 127.0.0.1:15353"
-                },
-                hosts = {},
+                nameservers = { {"127.0.0.1", 15353} },
                 order = {"LAST","A","AAAA", "CNAME" },
+                finalCacheOnly = true,
             }))
-            local host = "run.api7.ai"
-            for i = 1, 3 do
-                local answers, err = client.resolve(host)
-                if err then
-                    ngx.log(ngx.ERR, "Failed to resolve ", host, ": ", err)
-                    return
-                end
 
-                ngx.log(ngx.WARN, "Resolved ", host, ":")
-
-                local inspect = require("inspect")
-
-                for _, ans in ipairs(answers) do
-                    ngx.log(ngx.WARN, "Answer: ", inspect(ans))
-                end
-                ngx.sleep(5)
+            for i = 1, 10 do
+                local answers, err = client.resolve("run.api7.ai", { qtype = client.TYPE_A })
+                assert(err == nil, err)
+                assert(#answers > 0, "no answers returned")
+                assert(answers[1].address == "18.155.68.66", "unexpected address: " .. (answers[1].address or "nil"))
+                ngx.sleep(1)  -- Adding a sleep to avoid overwhelming the resolver
             end
+            ngx.say("passed")
         }
     }
 --- request
 GET /t
---- no_error_log
---- timeout: 20
+--- response_body
+passed
+--- grep_error_log eval
+qr/resolver query for run.api7.ai/
+--- grep_error_log_out
+resolver query for run.api7.ai
+resolver query for run.api7.ai
+resolver query for run.api7.ai
+--- timeout: 15

--- a/t/04-multi-answers-cache.t
+++ b/t/04-multi-answers-cache.t
@@ -32,8 +32,9 @@ __DATA__
             for i = 1, 10 do
                 local answers, err = client.resolve("run.api7.ai", { qtype = client.TYPE_A })
                 assert(err == nil, err)
-                assert(#answers > 0, "no answers returned")
+                assert(#answers == 2, "no answers returned")
                 assert(answers[1].address == "18.155.68.66", "unexpected address: " .. (answers[1].address or "nil"))
+                assert(answers[2].address == "18.155.68.67", "unexpected address: " .. (answers[2].address or "nil"))
                 ngx.sleep(1)  -- Adding a sleep to avoid overwhelming the resolver
             end
             ngx.say("passed")

--- a/t/04-multi-answers-cache.t
+++ b/t/04-multi-answers-cache.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::Nginx::Socket::Lua;
+
+plan tests => 2;
+
+our $HttpConfig = qq{
+    lua_package_path "deps/share/lua/5.1/?.lua;deps/share/lua/5.1/?.lua;src/?.lua;src/?/?.lua;src/?/init.lua;;";
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: load lua-resty-dns-client
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        access_by_lua_block {
+            local client = require("resty.dns.client")
+            assert(client.init({
+                resolvConf = {
+                    "nameserver 127.0.0.1:15353"
+                },
+                hosts = {},
+                order = {"LAST","A","AAAA", "CNAME" },
+            }))
+            local host = "run.api7.ai"
+            for i = 1, 3 do
+                local answers, err = client.resolve(host)
+                if err then
+                    ngx.log(ngx.ERR, "Failed to resolve ", host, ": ", err)
+                    return
+                end
+
+                ngx.log(ngx.WARN, "Resolved ", host, ":")
+
+                local inspect = require("inspect")
+
+                for _, ans in ipairs(answers) do
+                    ngx.log(ngx.WARN, "Answer: ", inspect(ans))
+                end
+                ngx.sleep(5)
+            end
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+--- timeout: 20

--- a/t/testdata/Corefile
+++ b/t/testdata/Corefile
@@ -1,0 +1,22 @@
+.:15353 {
+    log
+    errors
+    bufsize 512
+
+    template IN A {
+        match "^two\.cloudfront\.net\.$"
+        answer "{{ .Name }} 10 IN A 18.155.68.66"
+        fallthrough
+    }
+
+    template IN A {
+        match "^one\.cloudfront\.net\.$"
+        answer "{{ .Name }} 3 IN CNAME two.cloudfront.net."
+        fallthrough
+    }
+
+    template IN A {
+        match "^run\.api7\.ai\.$"
+        answer "{{ .Name }} 10 IN CNAME one.cloudfront.net."
+    }
+}

--- a/t/testdata/Corefile
+++ b/t/testdata/Corefile
@@ -6,6 +6,7 @@
     template IN A {
         match "^two\.cloudfront\.net\.$"
         answer "{{ .Name }} 10 IN A 18.155.68.66"
+        answer "{{ .Name }} 10 IN A 18.155.68.67"
         fallthrough
     }
 


### PR DESCRIPTION
## Background

The current DNS resolving and caching logic operates at the **RR (Resource Record) level**.  
Each record in a CNAME chain (CNAME / A / AAAA) is cached independently with its own TTL.

In real-world deployments, this behavior can lead to inconsistencies:

- An **intermediate CNAME record may expire or become unavailable**
- While the **final A / AAAA record is still present in cache**
- The resolver may continue using the cached final address
- This breaks the expected consistency of the DNS resolution chain

For gateway and traffic-routing components, this behavior can be undesirable.

---

## Practical Limitation of Intermediate Records

In addition to TTL consistency, there is a practical operational constraint:

> **Intermediate CNAME nodes are not always globally or persistently resolvable.**

In multi-region, multi-cloud, or third-party DNS environments (e.g. CDN or cloud-internal domains):

- Intermediate domains may only be resolvable in specific regions or networks
- Re-querying intermediate CNAME records may fail depending on location

This can cause traffic to be routed based on a DNS chain that is no longer valid from the resolver’s perspective.

---

## Example

```text
run.api7.ai.            10  IN CNAME   one.cloudfront.net.
one.cloudfront.net.     3   IN CNAME   two.cloudfront.net.
two.cloudfront.net.     10  IN A       18.155.68.66
```

Possible issue:

one.cloudfront.net expires or becomes unreachable in a given region


## What’s Changed

This PR introduces an optional configuration flag:

```lua
finalCacheOnly: true
```

When finalCacheOnly is enabled:

* The resolver only caches the final A / AAAA record

* The cache TTL is calculated as the minimum TTL across the entire CNAME chain

* Intermediate CNAME records are not cached or reused independently
