### PR TITLE
feat: add server_rewrite and precontent phases to supported_semaphore_wait_phases

### DIFF
--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -852,8 +852,10 @@ local function syncQuery(qname, r_opts, try_list, count)
   end
 
   local supported_semaphore_wait_phases = {
+    server_rewrite = true,
     rewrite = true,
     access = true,
+    precontent = true,
     content = true,
     timer = true,
     ssl_cert = true,


### PR DESCRIPTION
https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#server_rewrite_by_lua_block
https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#precontent_by_lua_block

These newly added phases in Lua all support `supported_semaphore_wait_phases`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNS client now supports semaphore operations in additional Nginx request processing phases, enabling proper DNS query functionality in more server configurations and request lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->