### PR TITLE
fix: exclude additional section records from finalCacheOnly results

### DIFF
--- a/spec/client_cache_spec.lua
+++ b/spec/client_cache_spec.lua
@@ -689,14 +689,18 @@ describe("[DNS client cache]", function()
           },
         }
       }
-      -- Should not return the section 3 A record as an answer
+      -- Should not return the section 3 A record as an answer.
+      -- With only CNAME in Answer section and no A record to dereference,
+      -- resolution should either fail or return CNAME only.
       local result, err = client.resolve("myservice", { qtype = client.TYPE_A })
-      if result then
-        -- If any result is returned, it must not be the section 3 record
+      if result and #result > 0 then
         for _, r in ipairs(result) do
           assert.not_equal(3, r.section)
           assert.not_equal("10.0.0.11", r.address)
         end
+      else
+        assert.truthy(result == nil or #result == 0,
+          "expected nil or empty result, got err: " .. tostring(err))
       end
     end)
 

--- a/spec/client_cache_spec.lua
+++ b/spec/client_cache_spec.lua
@@ -552,6 +552,157 @@ describe("[DNS client cache]", function()
   end)
 
 
+-- ==============================================
+--    finalCacheOnly with additional section
+-- ==============================================
+
+
+  describe("finalCacheOnly", function()
+
+    local lrucache, mock_records, config
+    before_each(function()
+      config = {
+        nameservers = { "8.8.8.8" },
+        ndots = 1,
+        search = { "domain.com" },
+        hosts = {},
+        resolvConf = {},
+        order = { "LAST", "SRV", "A", "AAAA", "CNAME" },
+        badTtl = 0.5,
+        staleTtl = 0.5,
+        enable_ipv6 = false,
+        finalCacheOnly = true,
+      }
+      assert(client.init(config))
+      lrucache = client.getcache()
+
+      query_func = function(self, original_query_func, qname, opts)
+        return mock_records[qname..":"..opts.qtype] or { errcode = 3, errstr = "name error" }
+      end
+    end)
+
+    it("excludes additional section records from results", function()
+      -- Simulates a DNS response with:
+      -- Section 1 (Answer): A record for the queried domain
+      -- Section 3 (Additional): A records for nameserver glue records
+      -- Without the fix, finalCacheOnly keeps all type-matching records
+      -- regardless of section, and overwrites their names to the queried
+      -- domain, causing wrong IPs to be returned.
+      mock_records = {
+        ["myservice.domain.com:" .. client.TYPE_A] = {
+          {
+            type = client.TYPE_A,
+            class = 1,
+            name = "myservice.domain.com",
+            address = "10.0.0.1",
+            ttl = 86400,
+            section = 1,
+          }, {
+            type = client.TYPE_A,
+            class = 1,
+            name = "ns1.otherdomain.com",
+            address = "10.0.0.11",
+            ttl = 1200,
+            section = 3,
+          }, {
+            type = client.TYPE_A,
+            class = 1,
+            name = "ns2.otherdomain.com",
+            address = "10.0.0.12",
+            ttl = 1200,
+            section = 3,
+          },
+        }
+      }
+      local result = client.resolve("myservice", { qtype = client.TYPE_A })
+      assert.equal(1, #result)
+      assert.equal("10.0.0.1", result[1].address)
+      assert.equal("myservice.domain.com", result[1].name)
+      assert.equal(1, result[1].section)
+      -- TTL should come from section 1 records only, not from section 3
+      assert.equal(86400, result[1].ttl)
+    end)
+
+    it("excludes additional section records when mixed with CNAME chain", function()
+      -- Simulates a DNS response with CNAME chain in Answer section
+      -- plus glue records in Additional section.
+      mock_records = {
+        ["myalias.domain.com:" .. client.TYPE_A] = {
+          {
+            type = client.TYPE_CNAME,
+            class = 1,
+            name = "myalias.domain.com",
+            cname = "target.domain.com",
+            ttl = 30,
+            section = 1,
+          }, {
+            type = client.TYPE_A,
+            class = 1,
+            name = "target.domain.com",
+            address = "10.0.0.1",
+            ttl = 86400,
+            section = 1,
+          }, {
+            type = client.TYPE_A,
+            class = 1,
+            name = "ns1.otherdomain.com",
+            address = "10.0.0.111",
+            ttl = 1200,
+            section = 3,
+          }, {
+            type = client.TYPE_A,
+            class = 1,
+            name = "ns2.otherdomain.com",
+            address = "10.0.0.112",
+            ttl = 1200,
+            section = 3,
+          },
+        }
+      }
+      local result = client.resolve("myalias", { qtype = client.TYPE_A })
+      assert.equal(1, #result)
+      assert.equal("10.0.0.1", result[1].address)
+      assert.equal("myalias.domain.com", result[1].name)
+      -- min TTL should be from CNAME chain (section 1 only): min(30, 86400) = 30
+      assert.equal(30, result[1].ttl)
+    end)
+
+    it("does not return additional section records even when answer section is empty", function()
+      -- When answer section has no A records but additional section does,
+      -- finalCacheOnly should not return the additional section A records.
+      mock_records = {
+        ["myservice.domain.com:" .. client.TYPE_A] = {
+          {
+            type = client.TYPE_CNAME,
+            class = 1,
+            name = "myservice.domain.com",
+            cname = "target.domain.com",
+            ttl = 30,
+            section = 1,
+          }, {
+            type = client.TYPE_A,
+            class = 1,
+            name = "ns1.otherdomain.com",
+            address = "10.0.0.11",
+            ttl = 1200,
+            section = 3,
+          },
+        }
+      }
+      -- Should not return the section 3 A record as an answer
+      local result, err = client.resolve("myservice", { qtype = client.TYPE_A })
+      if result then
+        -- If any result is returned, it must not be the section 3 record
+        for _, r in ipairs(result) do
+          assert.not_equal(3, r.section)
+          assert.not_equal("10.0.0.11", r.address)
+        end
+      end
+    end)
+
+  end)
+
+
   describe("hosts entries", function()
     -- hosts file names are cached for 10 years, verify that
     -- it is not overwritten with validTtl settings.

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -658,16 +658,16 @@ local function parseAnswer(qname, qtype, answers, try_list)
   if finalCacheOnly then
     -- when only caching final results, we remove all non-requested
     if #answers >= 2 and answers[#answers].type == qtype then
-      local SECTION_AR = 3  -- Additional section
+      local SECTION_AN = 1  -- Answer section
       local min_ttl = math.huge
       local j = 0
       for i = 1, #answers do
-        -- Exclude Additional section (section=3) records from both TTL
-        -- calculation and result set. They are glue records for nameservers
-        -- and must not be mixed with Answer section records. Without this
-        -- check, their names get overwritten to the queried name below,
-        -- causing wrong IPs to be returned for the queried domain.
-        if answers[i].section ~= SECTION_AR then
+        -- Only keep Answer section (section=1) records. Additional section
+        -- (section=3) records are glue records for nameservers and must not
+        -- be mixed with Answer section records. Without this check, their
+        -- names get overwritten to the queried name below, causing wrong
+        -- IPs to be returned for the queried domain.
+        if answers[i].section == SECTION_AN then
           min_ttl = math_min(answers[i].ttl, min_ttl)
           if answers[i].type == qtype then
             j = j + 1

--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -658,13 +658,21 @@ local function parseAnswer(qname, qtype, answers, try_list)
   if finalCacheOnly then
     -- when only caching final results, we remove all non-requested
     if #answers >= 2 and answers[#answers].type == qtype then
+      local SECTION_AR = 3  -- Additional section
       local min_ttl = math.huge
       local j = 0
       for i = 1, #answers do
-        min_ttl = math_min(answers[i].ttl, min_ttl)
-        if answers[i].type == qtype then
-          j = j + 1
-          answers[j] = answers[i]
+        -- Exclude Additional section (section=3) records from both TTL
+        -- calculation and result set. They are glue records for nameservers
+        -- and must not be mixed with Answer section records. Without this
+        -- check, their names get overwritten to the queried name below,
+        -- causing wrong IPs to be returned for the queried domain.
+        if answers[i].section ~= SECTION_AR then
+          min_ttl = math_min(answers[i].ttl, min_ttl)
+          if answers[i].type == qtype then
+            j = j + 1
+            answers[j] = answers[i]
+          end
         end
       end
       for i = 1, #answers do

--- a/t/02-timer-usage.t
+++ b/t/02-timer-usage.t
@@ -15,18 +15,18 @@ qq {
     init_worker_by_lua_block {
         local client = require("resty.dns.client")
         assert(client.init({
-            nameservers = { "8.8.8.8" },
+            nameservers = { {"127.0.0.1", 15353} },
             hosts = {}, -- empty tables to parse to prevent defaulting to /etc/hosts
             resolvConf = {}, -- and resolv.conf files
             order = { "A" },
         }))
-        local host = "httpbin.org"
+        local host = "svc1.test"
         local typ = client.TYPE_A
         for i = 1, 10 do
             client.resolve(host, { qtype = typ })
         end
 
-        local host = "mockbin.org"
+        local host = "svc2.test"
         for i = 1, 10 do
             client.resolve(host, { qtype = typ })
         end
@@ -40,22 +40,29 @@ qq {
     location = /t {
         access_by_lua_block {
             local client = require("resty.dns.client")
-            assert(client.init())
-            local host = "httpbin.org"
+            assert(client.init({
+                nameservers = { {"127.0.0.1", 15353} },
+                hosts = {},
+                resolvConf = {},
+                order = { "A" },
+            }))
+            local host = "svc1.test"
             local typ = client.TYPE_A
             local answers, err = client.resolve(host, { qtype = typ })
 
             if not answers then
                 ngx.say("failed to resolve: ", err)
+                return
             end
 
             ngx.say("first address name: ", answers[1].name)
 
-            host = "mockbin.org"
+            host = "svc2.test"
             answers, err = client.resolve(host, { qtype = typ })
 
             if not answers then
                 ngx.say("failed to resolve: ", err)
+                return
             end
 
             ngx.say("second address name: ", answers[1].name)
@@ -69,8 +76,8 @@ qq {
 --- request
 GET /t
 --- response_body
-first address name: httpbin.org
-second address name: mockbin.org
+first address name: svc1.test
+second address name: svc2.test
 workers: 6
 timers: 2
 --- no_error_log

--- a/t/testdata/Corefile
+++ b/t/testdata/Corefile
@@ -19,5 +19,17 @@
     template IN A {
         match "^run\.api7\.ai\.$"
         answer "{{ .Name }} 10 IN CNAME one.cloudfront.net."
+        fallthrough
+    }
+
+    template IN A {
+        match "^svc1\.test\.$"
+        answer "{{ .Name }} 300 IN A 192.168.1.1"
+        fallthrough
+    }
+
+    template IN A {
+        match "^svc2\.test\.$"
+        answer "{{ .Name }} 300 IN A 192.168.1.2"
     }
 }


### PR DESCRIPTION
## Problem

When `finalCacheOnly` is enabled (used by api7-ee-3-gateway) and `additional_section` is `true` (default in `resolve()`), the `parseAnswer()` function incorrectly returns DNS Additional section (section=3) glue records as answers for the queried domain.

### Root Cause

The `finalCacheOnly` block in `parseAnswer()` (L658-678) filters records by **type only**, not by name or section:

1. `additional_section=true` brings Section 3 glue records (A records for nameservers) into the flat `answers` list
2. `finalCacheOnly` keeps all records matching `qtype` (e.g., TYPE_A) — including Section 3 A records that belong to **different domains**
3. Line 674 then **overwrites all kept records names** to `check_qname`, making Section 3 records appear to belong to the queried domain
4. The subsequent name-based filter at line 687 no longer catches them since the name was already overwritten
5. Caller receives records with the correct queried name but **wrong IP address** (from nameserver glue records)

### Symptoms

- DNS resolution returns IP addresses from DNS Additional section (nameserver glue records) instead of the correct Answer section
- The returned record has `section: 3` (proof of wrong origin)
- TTL is set to `min_ttl` across all sections, producing unexpected TTL values
- The issue is **intermittent** because `math.random()` selects from all kept records, sometimes picking the correct one

### Fix

Added a `section == 1` (Answer section) check in the `finalCacheOnly` block to exclude non-Answer section records from both the result set and the `min_ttl` calculation. These are glue records for nameservers and should never be treated as answers for the queried domain.

### CI Fix

Fixed pre-existing `t/02-timer-usage.t` failure: the test relied on external DNS resolution (`8.8.8.8` for `httpbin.org` and `mockbin.org`) which fails in CI environments. Switched to use local CoreDNS server (`127.0.0.1:15353`) with test domains `svc1.test` and `svc2.test`. Also fixed a nil dereference bug in the test where resolve failure did not early-return before accessing the result.

### Test Coverage

Added 3 test cases for `finalCacheOnly` with Additional section records:
1. Basic case: Answer section A record + Additional section A glue records — only Answer section record returned
2. CNAME chain case: CNAME + A in Answer + glue records in Additional — correct resolution with proper min_ttl from section 1 only
3. Edge case: Only CNAME in Answer + A in Additional — Additional section A records not returned as answers