### PR TITLE
feat: add new supported phases to supported_semaphore_wait_phases

### DIFF
--- a/src/resty/dns/client.lua
+++ b/src/resty/dns/client.lua
@@ -861,9 +861,14 @@ local function syncQuery(qname, r_opts, try_list, count)
 
   local supported_semaphore_wait_phases = {
     rewrite = true,
+    server_rewrite = true,
     access = true,
+    precontent = true,
     content = true,
     timer = true,
+    proxy_ssl_cert = true,
+    proxy_ssl_verify = true,
+    ssl_client_hello = true,
     ssl_cert = true,
     ssl_session_fetch = true,
     preread = true,


### PR DESCRIPTION
These newly added phases in Lua support supported_semaphore_wait_phases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended DNS query synchronization support to additional Nginx execution contexts for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->